### PR TITLE
reduce allocations when ctx passed in to task is nil

### DIFF
--- a/ctx17.go
+++ b/ctx17.go
@@ -202,7 +202,9 @@ func (s *Scope) Task() Task {
 		}
 		initOnce.Do(init)
 		s, exit := newSpan(*ctx, f, args, NewId(), nil)
-		*ctx = s
+		if ctx != &unparented {
+			*ctx = s
+		}
 		return exit
 	})
 }
@@ -226,7 +228,9 @@ func (f *Func) Task(ctx *context.Context, args ...interface{}) func(*error) {
 		return nil
 	}
 	s, exit := newSpan(*ctx, f, args, NewId(), nil)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
@@ -239,7 +243,9 @@ func (f *Func) RemoteTrace(ctx *context.Context, spanId int64, trace *Trace,
 		f.scope.r.observeTrace(trace)
 	}
 	s, exit := newSpan(*ctx, f, args, spanId, trace)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
@@ -253,16 +259,17 @@ func (f *Func) ResetTrace(ctx *context.Context,
 	trace := NewTrace(NewId())
 	f.scope.r.observeTrace(trace)
 	s, exit := newSpan(*ctx, f, args, trace.Id(), trace)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
+var unparented = context.Background()
+
 func cleanCtx(ctx *context.Context) *context.Context {
-	// TODO: maybe we should generate some special parent for these unparented
-	// spans
 	if ctx == nil {
-		n := context.Background()
-		return &n
+		return &unparented
 	}
 	if *ctx == nil {
 		*ctx = context.Background()

--- a/xctx.go
+++ b/xctx.go
@@ -202,7 +202,9 @@ func (s *Scope) Task() Task {
 		}
 		initOnce.Do(init)
 		s, exit := newSpan(*ctx, f, args, NewId(), nil)
-		*ctx = s
+		if ctx != &unparented {
+			*ctx = s
+		}
 		return exit
 	})
 }
@@ -226,7 +228,9 @@ func (f *Func) Task(ctx *context.Context, args ...interface{}) func(*error) {
 		return nil
 	}
 	s, exit := newSpan(*ctx, f, args, NewId(), nil)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
@@ -239,7 +243,9 @@ func (f *Func) RemoteTrace(ctx *context.Context, spanId int64, trace *Trace,
 		f.scope.r.observeTrace(trace)
 	}
 	s, exit := newSpan(*ctx, f, args, spanId, trace)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
@@ -253,16 +259,17 @@ func (f *Func) ResetTrace(ctx *context.Context,
 	trace := NewTrace(NewId())
 	f.scope.r.observeTrace(trace)
 	s, exit := newSpan(*ctx, f, args, trace.Id(), trace)
-	*ctx = s
+	if ctx != &unparented {
+		*ctx = s
+	}
 	return exit
 }
 
+var unparented = context.Background()
+
 func cleanCtx(ctx *context.Context) *context.Context {
-	// TODO: maybe we should generate some special parent for these unparented
-	// spans
 	if ctx == nil {
-		n := context.Background()
-		return &n
+		return &unparented
 	}
 	if *ctx == nil {
 		*ctx = context.Background()


### PR DESCRIPTION
so i think this works out because if you pass nil in to the task, there's no way for you to observe the assignment to it. i'm only worried about the logic in newSpan and if that depends on having a unique parent context per nil.