### PR TITLE
callers: use frame.Function to get function name

### DIFF
--- a/callers.go
+++ b/callers.go
@@ -39,10 +39,10 @@ func callerFunc(frames int) string {
 		return "unknown"
 	}
 	frame, _ := runtime.CallersFrames(pc[:]).Next()
-	if frame.Func == nil {
+	if frame.Function == "" {
 		return "unknown"
 	}
-	slash_pieces := strings.Split(frame.Func.Name(), "/")
+	slash_pieces := strings.Split(frame.Function, "/")
 	dot_pieces := strings.SplitN(slash_pieces[len(slash_pieces)-1], ".", 2)
 	return dot_pieces[len(dot_pieces)-1]
 }


### PR DESCRIPTION
Based on the godoc: https://golang.org/pkg/runtime/#Frame

`Frame.Func` only returns Go function in running binary, but sometimes we also want to track other types function called in the code