### PR TITLE
newSpan: Fetch trace observer in exit function

### DIFF
--- a/collect/xctx.go
+++ b/collect/xctx.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
 	"github.com/spacemonkeygo/monkit/v3"
+	"golang.org/x/net/context"
 )
 
 // WatchForSpans will watch for spans that 'matcher' returns true for. As soon

--- a/ctx.go
+++ b/ctx.go
@@ -137,7 +137,9 @@ func newSpan(ctx context.Context, f *Func, args []interface{},
 
 		trace.decrementSpans()
 
-		if observer != nil {
+		// Re-fetch the observer, in case the value has changed since newSpan
+		// was called
+		if observer := trace.getObserver(); observer != nil {
 			observer.Finish(sctx, s, err, panicked, finish)
 		}
 

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,0 +1,61 @@
+package monkit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestLateObserver checks that if you add an observer to a trace after it has
+// begun, the original span that started the trace will also be observed
+func TestLateObserver(t *testing.T) {
+	ctx := context.Background()
+	mon := Package()
+	mock := &mockSpanObserver{}
+	func() {
+		// Start the first span, this is the trace
+		defer mon.Task()(&ctx)(nil)
+
+		// Start a second span, this is a span on the trace, but still occurs
+		// before we register a span observer
+		defer mon.Task()(&ctx)(nil)
+
+		// Now start observing all new traces
+		mon.r.ObserveTraces(func(t *Trace) {
+			t.ObserveSpans(mock)
+		})
+
+		// Now go through all root spans, and observe the traces associated
+		// with those spans
+		mon.r.RootSpans(func(s *Span) {
+			s.Trace().ObserveSpans(mock)
+		})
+
+		// One more after-the-fact
+		defer mon.Task()(&ctx)(nil)
+
+		// Here is a new trace, to prove that is working
+		ctx2 := context.Background()
+		defer mon.Task()(&ctx2)(nil)
+	}()
+	expStarts := 2
+	expFinishes := 4
+	if mock.starts != expStarts {
+		t.Errorf("Expected %d, got %d", expStarts, mock.starts)
+	}
+	if mock.finishes != expFinishes {
+		t.Errorf("Expected %d, got %d", expFinishes, mock.finishes)
+	}
+}
+
+type mockSpanObserver struct {
+	starts, finishes int
+}
+
+func (m *mockSpanObserver) Start(s *Span) {
+	m.starts++
+}
+
+func (m *mockSpanObserver) Finish(s *Span, err error, panicked bool, finish time.Time) {
+	m.finishes++
+}


### PR DESCRIPTION
In the exit function for a span, re-fetch the trace observer in case the
value has changed.