### PR TITLE
Inherent existing trace tags when start a new one

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -272,6 +272,33 @@ func (f *Func) ResetTrace(ctx *context.Context,
 	return exit
 }
 
+// RestartTrace is like Func.Task, except it always creates a new Trace and inherient
+// all tags from the existing trace.
+func (f *Func) RestartTrace(ctx *context.Context, args ...interface{}) func(*error) {
+	existingSpan := SpanFromCtx(*ctx)
+	if existingSpan == nil {
+		return f.ResetTrace(ctx, args)
+	}
+	existingTrace := existingSpan.Trace()
+	if existingTrace == nil {
+		return f.ResetTrace(ctx, args)
+	}
+
+	ctx = cleanCtx(ctx)
+	if ctx == &taskSecret && taskArgs(f, args) {
+		return nil
+	}
+	trace := NewTrace(NewId())
+	trace.SetAll(existingTrace.GetAll())
+	f.scope.r.observeTrace(trace)
+	s, exit := newSpan(*ctx, f, args, trace.Id(), trace)
+
+	if ctx != &unparented {
+		*ctx = s
+	}
+	return exit
+}
+
 var unparented = context.Background()
 
 func cleanCtx(ctx *context.Context) *context.Context {

--- a/ctx.go
+++ b/ctx.go
@@ -289,7 +289,7 @@ func (f *Func) RestartTrace(ctx *context.Context, args ...interface{}) func(*err
 		return nil
 	}
 	trace := NewTrace(NewId())
-	trace.SetAll(existingTrace.GetAll())
+	trace.copyFrom(existingTrace)
 	f.scope.r.observeTrace(trace)
 	s, exit := newSpan(*ctx, f, args, trace.Id(), trace)
 

--- a/trace.go
+++ b/trace.go
@@ -112,14 +112,18 @@ func (t *Trace) Id() int64 { return t.id }
 func (t *Trace) GetAll() (val map[interface{}]interface{}) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	return t.vals
+	new := make(map[interface{}]interface{}, len(t.vals))
+	for k, v := range t.vals {
+		new[k] = v
+	}
+	return new
 }
 
 // SetAll replace all key/value on a trace with a new sets of key/value.
-func (t *Trace) SetAll(vals map[interface{}]interface{}) {
+func (t *Trace) copyFrom(s *Trace) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.vals = vals
+	t.vals = s.vals
 }
 
 // Get returns a value associated with a key on a trace. See Set.

--- a/trace.go
+++ b/trace.go
@@ -108,6 +108,20 @@ func removeObserverFrom(parent **spanObserverTuple, ref *spanObserverTuple) (
 // Id returns the id of the Trace
 func (t *Trace) Id() int64 { return t.id }
 
+// GetAll returns values associated with a trace. See SetAll.
+func (t *Trace) GetAll() (val map[interface{}]interface{}) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.vals
+}
+
+// SetAll replace all key/value on a trace with a new sets of key/value.
+func (t *Trace) SetAll(vals map[interface{}]interface{}) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	t.vals = vals
+}
+
 // Get returns a value associated with a key on a trace. See Set.
 func (t *Trace) Get(key interface{}) (val interface{}) {
 	t.mtx.Lock()

--- a/trace.go
+++ b/trace.go
@@ -119,13 +119,6 @@ func (t *Trace) GetAll() (val map[interface{}]interface{}) {
 	return new
 }
 
-// SetAll replace all key/value on a trace with a new sets of key/value.
-func (t *Trace) copyFrom(s *Trace) {
-	t.mtx.Lock()
-	defer t.mtx.Unlock()
-	t.vals = s.vals
-}
-
 // Get returns a value associated with a key on a trace. See Set.
 func (t *Trace) Get(key interface{}) (val interface{}) {
 	t.mtx.Lock()
@@ -145,6 +138,13 @@ func (t *Trace) Set(key, val interface{}) {
 		t.vals[key] = val
 	}
 	t.mtx.Unlock()
+}
+
+// copyFrom replace all key/value on a trace with a new sets of key/value.
+func (t *Trace) copyFrom(s *Trace) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	t.vals = s.vals
 }
 
 func (t *Trace) incrementSpans() { atomic.AddInt64(&t.spanCount, 1) }

--- a/trace.go
+++ b/trace.go
@@ -142,9 +142,10 @@ func (t *Trace) Set(key, val interface{}) {
 
 // copyFrom replace all key/value on a trace with a new sets of key/value.
 func (t *Trace) copyFrom(s *Trace) {
+	vals := s.GetAll()
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.vals = s.vals
+	t.vals = vals
 }
 
 func (t *Trace) incrementSpans() { atomic.AddInt64(&t.spanCount, 1) }


### PR DESCRIPTION
We need the ability to preserve metadata from existing trace when we start a new trace