### PR TITLE
reparent orphaned spans to grandparents

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -121,9 +121,17 @@ func newSpan(ctx context.Context, f *Func, args []interface{},
 		s.children.Iterate(func(child *Span) {
 			children = append(children, child)
 		})
+		s.children.Clear()
 		s.mtx.Unlock()
-		for _, child := range children {
-			child.orphan()
+
+		if s.parent != nil && !orphaned {
+			for _, child := range children {
+				s.parent.addChild(child)
+			}
+		} else {
+			for _, child := range children {
+				child.orphan()
+			}
 		}
 
 		if s.parent != nil {

--- a/spanbag.go
+++ b/spanbag.go
@@ -23,6 +23,11 @@ type spanBag struct {
 	rest  map[*Span]int32
 }
 
+func (b *spanBag) Clear() {
+	b.first = nil
+	b.rest = nil
+}
+
 func (b *spanBag) Add(s *Span) {
 	if b.first == nil {
 		b.first = s


### PR DESCRIPTION
Consider code like

```go
func Foo(ctx context.Context) (err error) {
    defer mon.Task()(&ctx)(&err)
    stream := Bar(ctx)
    stream.RPC()
    stream.RPC()
    return nil
}

func Bar(ctx context.Context) (Stream) {
    defer mon.Task()(&ctx)(&err)
    return newStream(ctx)
}
```

where the `Stream` type internally stores the context passed to it for the RPC invocations. Arguably, this code doesn't use contexts correctly because the RPCs should be passed the ctx, but this is how gRPC works.

Because the `Stream` context is a child of the `Bar` context that is exited, the RPC invocations, if monitored, will be considered orphaned. Instead, this change makes it so that they are parented by `Foo`.

The tree of spans will become something closer to a DAG, but it should be the case that there is only one reachable path to a child at a time through non-done spans.