### PR TITLE
Reduce allocations for mon.Task()(&ctx)(&err)

### DIFF
--- a/callers.go
+++ b/callers.go
@@ -42,7 +42,32 @@ func callerFunc(frames int) string {
 	if frame.Function == "" {
 		return "unknown"
 	}
-	slash_pieces := strings.Split(frame.Function, "/")
-	dot_pieces := strings.SplitN(slash_pieces[len(slash_pieces)-1], ".", 2)
-	return dot_pieces[len(dot_pieces)-1]
+	funcname, ok := extractFuncName(frame.Function)
+	if !ok {
+		return "unknown"
+	}
+	return funcname
+}
+
+// extractFuncName splits fully qualified function name:
+//
+// Input:
+//   "github.com/spacemonkeygo/monkit/v3.BenchmarkTask.func1"
+// Output:
+//   funcname: "BenchmarkTask.func1"
+func extractFuncName(fullyQualifiedName string) (funcname string, ok bool) {
+	lastSlashPos := strings.LastIndexByte(fullyQualifiedName, '/')
+	if lastSlashPos < 0 || lastSlashPos+1 >= len(fullyQualifiedName) {
+		// fullyQualifiedName ended with slash.
+		return "", false
+	}
+
+	qualifiedName := fullyQualifiedName[lastSlashPos+1:]
+	packageDotPos := strings.IndexByte(qualifiedName, '.')
+	if packageDotPos < 0 || packageDotPos+1 >= len(qualifiedName) {
+		// qualifiedName ended with a dot
+		return "", false
+	}
+
+	return qualifiedName[packageDotPos+1:], true
 }

--- a/callers_test.go
+++ b/callers_test.go
@@ -1,0 +1,22 @@
+package monkit
+
+import "testing"
+
+func TestExtractFuncName(t *testing.T) {
+	for _, test := range []struct {
+		in string
+		fn string
+		ok bool
+	}{
+		{"", "", false},
+		{"a/", "", false},
+		{"a/v.", "", false},
+		{"a/v.x", "x", true},
+		{"github.com/spacemonkeygo/monkit/v3.BenchmarkTask.func1", "BenchmarkTask.func1", true},
+	} {
+		fn, ok := extractFuncName(test.in)
+		if fn != test.fn || ok != test.ok {
+			t.Errorf("failed %q, got %q %v, expected %q %v", test.in, fn, ok, test.fn, test.ok)
+		}
+	}
+}

--- a/ctx.go
+++ b/ctx.go
@@ -198,16 +198,15 @@ type Task func(ctx *context.Context, args ...interface{}) func(*error)
 func (s *Scope) Task(tags ...SeriesTag) Task {
 	var initOnce sync.Once
 	var f *Func
-	init := func() {
-		f = s.FuncNamed(callerFunc(3), tags...)
-	}
 	return Task(func(ctx *context.Context,
 		args ...interface{}) func(*error) {
 		ctx = cleanCtx(ctx)
 		if ctx == &taskSecret && taskArgs(f, args) {
 			return nil
 		}
-		initOnce.Do(init)
+		initOnce.Do(func() {
+			f = s.FuncNamed(callerFunc(3), tags...)
+		})
 		s, exit := newSpan(*ctx, f, args, NewId(), nil)
 		if ctx != &unparented {
 			*ctx = s

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -59,3 +59,28 @@ func (m *mockSpanObserver) Start(s *Span) {
 func (m *mockSpanObserver) Finish(s *Span, err error, panicked bool, finish time.Time) {
 	m.finishes++
 }
+
+func BenchmarkTask(b *testing.B) {
+	mon := Package()
+	pctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		var err error
+		func() {
+			ctx := pctx
+			defer mon.Task()(&ctx)(&err)
+		}()
+	}
+}
+func BenchmarkTaskNested(b *testing.B) {
+	mon := Package()
+	pctx := context.Background()
+	var errout error
+	defer mon.Task()(&pctx)(&errout)
+	for i := 0; i < b.N; i++ {
+		var err error
+		func() {
+			ctx := pctx
+			defer mon.Task()(&ctx)(&err)
+		}()
+	}
+}

--- a/scope.go
+++ b/scope.go
@@ -74,7 +74,13 @@ func (s *Scope) newSource(name string, constructor func() StatSource) (
 // unique Func. SeriesTags are not sorted, so keep the order consistent to avoid
 // unintentionally creating new unique Funcs.
 func (s *Scope) FuncNamed(name string, tags ...SeriesTag) *Func {
+	var sourceNameSize int
+	sourceNameSize += 5 + len(name) + len(tags)*2
+	for _, tag := range tags {
+		sourceNameSize += len(tag.Key) + len(tag.Val)
+	}
 	var sourceName strings.Builder
+	sourceName.Grow(sourceNameSize)
 	sourceName.WriteString("func:")
 	sourceName.WriteString(name)
 	for _, tag := range tags {
@@ -83,6 +89,7 @@ func (s *Scope) FuncNamed(name string, tags ...SeriesTag) *Func {
 		sourceName.WriteByte('=')
 		sourceName.WriteString(tag.Val)
 	}
+
 	source := s.newSource(sourceName.String(), func() StatSource {
 		key := NewSeriesKey("function").WithTag("name", name)
 		for _, tag := range tags {


### PR DESCRIPTION
This removes few allocs from:

* FuncNamed
* callerFunc
* Scope.Task

```
  name           old time/op    new time/op    delta
  Task-32          2.28µs ± 2%    1.98µs ± 2%  -12.83%  (p=0.008 n=5+5)
  TaskNested-32    2.19µs ± 1%    1.88µs ± 2%  -14.48%  (p=0.008 n=5+5)

  name           old alloc/op   new alloc/op   delta
  Task-32            736B ± 0%      616B ± 0%  -16.30%  (p=0.008 n=5+5)
  TaskNested-32      696B ± 0%      576B ± 0%  -17.24%  (p=0.008 n=5+5)

  name           old allocs/op  new allocs/op  delta
  Task-32            16.0 ± 0%      12.0 ± 0%  -25.00%  (p=0.008 n=5+5)
  TaskNested-32      15.0 ± 0%      11.0 ± 0%  -26.67%  (p=0.008 n=5+5)
```