### PR TITLE
monkit: add context-sensitive delta calculations.

### DIFF
--- a/meter.go
+++ b/meter.go
@@ -51,11 +51,10 @@ type meterBucket struct {
 //   }
 //
 type Meter struct {
-	mtx       sync.Mutex
-	total     int64
-	lastTotal int64
-	slices    [ticksToKeep]meterBucket
-	key       SeriesKey
+	mtx    sync.Mutex
+	total  int64
+	slices [ticksToKeep]meterBucket
+	key    SeriesKey
 }
 
 // NewMeter constructs a Meter
@@ -116,48 +115,42 @@ func (e *Meter) tick(now time.Time) {
 	e.mtx.Unlock()
 }
 
-// stats returns the calculated values rate, total, and delta inside of a lock.
-// delta is only nonzero if resetDelta is true.
-func (e *Meter) stats(now time.Time, resetDelta bool) (rate float64, total, delta int64) {
+func (e *Meter) stats(now time.Time) (rate float64, total int64) {
 	current := int64(0)
 	e.mtx.Lock()
 	start := e.slices[0].start
 	for i := 0; i < ticksToKeep; i++ {
 		current += e.slices[i].count
 	}
-	total = e.total + current
-	if resetDelta {
-		delta = total - e.lastTotal
-		e.lastTotal = total
-	}
+	total = e.total
 	e.mtx.Unlock()
+	total += current
 	duration := now.Sub(start).Seconds()
 	if duration > 0 {
 		rate = float64(current) / duration
 	} else {
 		rate = 0
 	}
-	return rate, total, delta
+	return rate, total
 }
 
 // Rate returns the rate over the internal sliding window
 func (e *Meter) Rate() float64 {
-	rate, _, _ := e.stats(monotime.Now(), false)
+	rate, _ := e.stats(monotime.Now())
 	return rate
 }
 
 // Total returns the total over the internal sliding window
 func (e *Meter) Total() float64 {
-	_, total, _ := e.stats(monotime.Now(), false)
+	_, total := e.stats(monotime.Now())
 	return float64(total)
 }
 
 // Stats implements the StatSource interface
 func (e *Meter) Stats(cb func(key SeriesKey, field string, val float64)) {
-	rate, total, delta := e.stats(monotime.Now(), true)
+	rate, total := e.stats(monotime.Now())
 	cb(e.key, "rate", rate)
 	cb(e.key, "total", float64(total))
-	cb(e.key, "delta", float64(delta))
 }
 
 // DiffMeter is a StatSource that shows the difference between
@@ -183,8 +176,8 @@ func NewDiffMeter(key SeriesKey, meter1, meter2 *Meter) *DiffMeter {
 // Stats implements the StatSource interface
 func (m *DiffMeter) Stats(cb func(key SeriesKey, field string, val float64)) {
 	now := monotime.Now()
-	rate1, total1, _ := m.meter1.stats(now, false)
-	rate2, total2, _ := m.meter2.stats(now, false)
+	rate1, total1 := m.meter1.stats(now)
+	rate2, total2 := m.meter2.stats(now)
 	cb(m.key, "rate", rate1-rate2)
 	cb(m.key, "total", float64(total1-total2))
 }

--- a/present/path.go
+++ b/present/path.go
@@ -70,7 +70,6 @@ func curry(reg *monkit.Registry,
 // two) to every monitored function.
 func FromRequest(reg *monkit.Registry, path string, query url.Values) (
 	f Result, contentType string, err error) {
-
 	defer func() {
 		if err != nil {
 			return
@@ -115,7 +114,7 @@ func FromRequest(reg *monkit.Registry, path string, query url.Values) (
 
 	case "stats":
 		switch second {
-		case "", "text":
+		case "", "text", "old":
 			return func(w io.Writer) error {
 				return StatsText(reg, w)
 			}, "text/plain; charset=utf-8", nil
@@ -123,10 +122,6 @@ func FromRequest(reg *monkit.Registry, path string, query url.Values) (
 			return func(w io.Writer) error {
 				return StatsJSON(reg, w)
 			}, "application/json; charset=utf-8", nil
-		case "old":
-			return func(w io.Writer) error {
-				return StatsOld(reg, w)
-			}, "text/plain; charset=utf-8", nil
 		}
 
 	case "trace":

--- a/present/path.go
+++ b/present/path.go
@@ -70,6 +70,7 @@ func curry(reg *monkit.Registry,
 // two) to every monitored function.
 func FromRequest(reg *monkit.Registry, path string, query url.Values) (
 	f Result, contentType string, err error) {
+
 	defer func() {
 		if err != nil {
 			return

--- a/present/stats.go
+++ b/present/stats.go
@@ -21,17 +21,8 @@ import (
 	"github.com/spacemonkeygo/monkit/v3"
 )
 
-// StatsOld writes all of the name/value statistics pairs the Registry knows
-// to w in a text format.
-func StatsOld(r *monkit.Registry, w io.Writer) (err error) {
-	r.Stats(func(key monkit.SeriesKey, field string, val float64) {
-		if err != nil {
-			return
-		}
-		_, err = fmt.Fprintf(w, "%s=%f\n", key.WithField(field), val)
-	})
-	return err
-}
+// StatsOld is deprecated.
+var StatsOld = StatsText
 
 // StatsText writes all of the name/value statistics pairs the Registry knows
 // to w in a text format.

--- a/present/stats.go
+++ b/present/stats.go
@@ -22,7 +22,7 @@ import (
 )
 
 // StatsOld is deprecated.
-var StatsOld = StatsText
+func StatsOld(r *monkit.Registry, w io.Writer) error { return StatsText(r, w) }
 
 // StatsText writes all of the name/value statistics pairs the Registry knows
 // to w in a text format.

--- a/scope.go
+++ b/scope.go
@@ -304,8 +304,12 @@ func (s *Scope) allNamedSources() (sources []namedSource) {
 
 // Stats implements the StatSource interface.
 func (s *Scope) Stats(cb func(key SeriesKey, field string, val float64)) {
+	cbWithScope := func(key SeriesKey, field string, val float64) {
+		cb(key.WithTag("scope", s.name), field, val)
+	}
+
 	for _, namedSource := range s.allNamedSources() {
-		namedSource.source.Stats(cb)
+		namedSource.source.Stats(cbWithScope)
 	}
 
 	s.mtx.Lock()
@@ -313,7 +317,7 @@ func (s *Scope) Stats(cb func(key SeriesKey, field string, val float64)) {
 	s.mtx.Unlock()
 
 	for _, source := range chains {
-		source.Stats(cb)
+		source.Stats(cbWithScope)
 	}
 }
 

--- a/transform.go
+++ b/transform.go
@@ -65,15 +65,16 @@ func (dt *DeltaTransformer) Transform(cb func(SeriesKey, string, float64)) func(
 			return
 		}
 
-		dt.mtx.Lock()
-		defer dt.mtx.Unlock()
-
 		mapIndex := key.WithField(field)
+
+		dt.mtx.Lock()
 		lastTotal, found := dt.lastTotals[mapIndex]
+		dt.lastTotals[mapIndex] = val
+		dt.mtx.Unlock()
+
+		cb(key, field, val)
 		if found {
 			cb(key, "delta", val-lastTotal)
 		}
-		dt.lastTotals[mapIndex] = val
-		cb(key, field, val)
 	}
 }

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2021 Storj Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monkit
+
+import (
+	"sync"
+)
+
+// CallbackTransformer will take a provided callback and return a transformed one.
+type CallbackTransformer interface {
+	Transform(func(SeriesKey, string, float64)) func(SeriesKey, string, float64)
+}
+
+// CallbackTransformerFunc is a single function that implements
+// CallbackTransformer's Transform.
+type CallbackTransformerFunc func(func(SeriesKey, string, float64)) func(SeriesKey, string, float64)
+
+// Transform implements CallbackTransformer.
+func (f CallbackTransformerFunc) Transform(cb func(SeriesKey, string, float64)) func(SeriesKey, string, float64) {
+	return f(cb)
+}
+
+// TransformStatSource will make sure that a StatSource has the provided
+// CallbackTransformers applied to callbacks given to the StatSource.
+func TransformStatSource(s StatSource, transformers ...CallbackTransformer) StatSource {
+	return StatSourceFunc(func(cb func(key SeriesKey, field string, val float64)) {
+		for _, t := range transformers {
+			cb = t.Transform(cb)
+		}
+		s.Stats(cb)
+	})
+}
+
+// DeltaTransformer calculates deltas from any total fields. It keeps internal
+// state to keep track of the previous totals, so care should be taken to use
+// a different DeltaTransformer per output.
+type DeltaTransformer struct {
+	mtx        sync.Mutex
+	lastTotals map[string]float64
+}
+
+// NewDeltaTransformer creates a new DeltaTransformer with its own idea of the
+// last totals seen.
+func NewDeltaTransformer() *DeltaTransformer {
+	return &DeltaTransformer{lastTotals: map[string]float64{}}
+}
+
+// Transform implements CallbackTransformer.
+func (dt *DeltaTransformer) Transform(cb func(SeriesKey, string, float64)) func(SeriesKey, string, float64) {
+	return func(key SeriesKey, field string, val float64) {
+		if field != "total" {
+			cb(key, field, val)
+			return
+		}
+
+		dt.mtx.Lock()
+		defer dt.mtx.Unlock()
+
+		mapIndex := key.WithField(field)
+		lastTotal, found := dt.lastTotals[mapIndex]
+		if found {
+			cb(key, "delta", val-lastTotal)
+		}
+		dt.lastTotals[mapIndex] = val
+		cb(key, field, val)
+	}
+}


### PR DESCRIPTION
one downside with the previous delta implementation is that if two different metric outputs were in use (e.g. a udp packet sink
and prometheus scraping), the delta would get reset in between different outputs, instead of being output-specific.

this change rethinks delta calculations as being a context-specific transform applied on top of existing metrics. this allows for different output styles to have their own transforms applied.

one downside of this change is deltas go away without downstream changes, so go.mod shouldn't be bumped to this version without appropriate changes to include the DeltaTransformer in the right calls to (*Registry).WithTransformers