### PR TITLE
fixes for live trace selection

### DIFF
--- a/present/json.go
+++ b/present/json.go
@@ -41,8 +41,7 @@ func formatSpan(s *monkit.Span) interface{} {
 		Annotations [][]string `json:"annotations"`
 	}{}
 	js.Id = s.Id()
-	if s.Parent() != nil {
-		parent_id := s.Parent().Id()
+	if parent_id, ok := s.ParentId(); ok {
 		js.ParentId = &parent_id
 	}
 	js.Func.Package = s.Func().Scope().Name()
@@ -82,8 +81,7 @@ func formatFinishedSpan(s *collect.FinishedSpan) interface{} {
 		Annotations [][]string `json:"annotations"`
 	}{}
 	js.Id = s.Span.Id()
-	if s.Span.Parent() != nil {
-		parent_id := s.Span.Parent().Id()
+	if parent_id, ok := s.Span.ParentId(); ok {
 		js.ParentId = &parent_id
 	}
 	js.Func.Package = s.Span.Func().Scope().Name()

--- a/present/spans.go
+++ b/present/spans.go
@@ -87,8 +87,8 @@ func outputTextSpan(w io.Writer, s *monkit.Span, indent string) (err error) {
 	if s.Orphaned() {
 		orphaned = ", orphaned"
 	}
-	_, err = fmt.Fprintf(w, "%s[%d] %s(%s) (elapsed: %s%s)\n",
-		indent, s.Id(), s.Func().FullName(), strings.Join(s.Args(), ", "),
+	_, err = fmt.Fprintf(w, "%s[%d,%d] %s(%s) (elapsed: %s%s)\n",
+		indent, s.Id(), s.Trace().Id(), s.Func().FullName(), strings.Join(s.Args(), ", "),
 		s.Duration(), orphaned)
 	if err != nil {
 		return err

--- a/span.go
+++ b/span.go
@@ -152,14 +152,21 @@ func interfacesToString(args []interface{}) string {
 // Id returns the Span id.
 func (s *Span) Id() int64 { return s.id }
 
+// ParentId returns the id of the parent Span, if it has a parent.
+func (s *Span) ParentId() (int64, bool) {
+	if s.parentId != nil {
+		return *s.parentId, true
+	} else if s.parent != nil {
+		return s.parent.id, true
+	}
+	return 0, false
+}
+
 // Func returns the Func that kicked off this Span.
 func (s *Span) Func() *Func { return s.f }
 
 // Trace returns the Trace this Span is associated with.
 func (s *Span) Trace() *Trace { return s.trace }
-
-// Parent returns the Parent Span.
-func (s *Span) Parent() *Span { return s.parent }
 
 // Annotations returns any added annotations created through the Span Annotate
 // method


### PR DESCRIPTION
- removes `Parent() *Span` api because sometimes the parent is just a remote id
- fixes for the html template for trace/remote
- adds and uses a sampled callback for allowing things to register observing spans when a trace transitions to sampled
- removes RestartTrace because it was unused and misguided
