### PR TITLE
http: helper methods to propagate monkit traces via HTTP calls

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -14,13 +14,13 @@ import (
 // TraceRequest will perform an HTTP request, creating a new Span for the HTTP
 // request and sending the Span in the HTTP request headers.
 // Compare to http.Client.Do.
-func TraceRequest(ctx context.Context, scope *monkit.Scope, cl Client, req *http.Request, sampled func(trace *monkit.Trace) bool) (
+func TraceRequest(ctx context.Context, scope *monkit.Scope, cl Client, req *http.Request) (
 	resp *http.Response, err error) {
 	defer scope.TaskNamed(req.Method)(&ctx)(&err)
 
 	s := monkit.SpanFromCtx(ctx)
 	s.Annotate("http.uri", req.URL.String())
-	TraceInfoFromSpan(s, sampled).SetHeader(req.Header)
+	TraceInfoFromSpan(s).SetHeader(req.Header)
 	resp, err = cl.Do(req)
 	if err != nil {
 		return resp, err

--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spacemonkeygo/monkit/v3"
+)
+
+// TraceRequest will perform an HTTP request, creating a new Span for the HTTP
+// request and sending the Span in the HTTP request headers.
+// Compare to http.Client.Do.
+func TraceRequest(ctx context.Context, scope *monkit.Scope, cl Client, req *http.Request, sampled func(trace *monkit.Trace) bool) (
+	resp *http.Response, err error) {
+	defer scope.TaskNamed(req.Method)(&ctx)(&err)
+
+	s := monkit.SpanFromCtx(ctx)
+	s.Annotate("http.uri", req.URL.String())
+	TraceInfoFromSpan(s, sampled).SetHeader(req.Header)
+	resp, err = cl.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	s.Annotate("http.responsecode", fmt.Sprint(resp.StatusCode))
+	return resp, nil
+}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/spacemonkeygo/monkit/v3"
+)
+
+type caller func(ctx context.Context, request *http.Request) (*http.Response, error)
+
+func TestPropagation(t *testing.T) {
+	mon := monkit.Package()
+
+	addr, closeServer := startHTTPServer(t)
+
+	defer closeServer()
+
+	ctx := context.Background()
+	trace := monkit.NewTrace(monkit.NewId())
+	setSampled(trace)
+
+	defer mon.Func().RemoteTrace(&ctx, 0, trace)(nil)
+
+	body, header := clientCallWithRetry(t, ctx, addr, func(ctx context.Context, request *http.Request) (*http.Response, error) {
+		return TraceRequest(ctx, monkit.ScopeNamed("client"), http.DefaultClient, request, getSampled)
+	})
+
+	s := monkit.SpanFromCtx(ctx)
+
+	expected := fmt.Sprintf("%d/hello/true", s.Id())
+
+	if string(body) != expected {
+		t.Fatalf("%s!=%s", string(body), expected)
+	}
+	if header != "" {
+		t.Fatalf("tracestate should be empty: %s", header)
+	}
+}
+
+// TestForcedSample checks if sampling can be turned on without having trace/span on client side.
+func TestForcedSample(t *testing.T) {
+
+	addr, closeServer := startHTTPServer(t)
+
+	defer closeServer()
+
+	body, header := clientCallWithRetry(t, context.Background(), addr, func(ctx context.Context, request *http.Request) (*http.Response, error) {
+		request.Header.Set(traceStateHeader, "sampled=true")
+		return http.DefaultClient.Do(request)
+	})
+
+	expected := "0/hello/true"
+
+	if string(body) != expected {
+		t.Fatalf("%s!=%s", string(body), expected)
+	}
+	if header == "" {
+		t.Fatalf("tracestate should not be empty: %s", header)
+	}
+}
+
+func setSampled(trace *monkit.Trace) {
+	trace.Set("testsampled", true)
+}
+
+func getSampled(trace *monkit.Trace) bool {
+	sampled, ok := trace.Get("testsampled").(bool)
+	return ok && sampled
+}
+
+func clientCallWithRetry(t *testing.T, ctx context.Context, addr string, caller caller) (string, string) {
+	var err error
+	for i := 0; i < 100; i++ {
+		body, header, err := clientCall(ctx, addr, caller)
+		if err == nil {
+			return body, header
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal(err)
+	return "", ""
+}
+
+func clientCall(ctx context.Context, addr string, caller caller) (string, string, error) {
+	request, err := http.NewRequest("GET", addr, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	resp, err := caller(ctx, request)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+	return string(body), resp.Header.Get(traceStateHeader), nil
+}
+
+func startHTTPServer(t *testing.T) (addr string, def func()) {
+	mux := http.NewServeMux()
+	mon := monkit.Package()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		defer mon.Task()(&ctx)(nil)
+		s := monkit.SpanFromCtx(ctx)
+
+		grandParent := int64(0)
+		parent, found := s.ParentId()
+		if found {
+			// we are interested about the parent of the parent,
+			// created by the TraceHandler
+			monkit.RootSpans(func(s *monkit.Span) {
+				if s.Id() == parent {
+					grandParent, _ = s.ParentId()
+				}
+			})
+		}
+		_, _ = fmt.Fprintf(w, "%d/%s/%v", grandParent, "hello", s.Trace().Get("testsampled"))
+	})
+
+	listener, err := net.Listen("tcp", ":0")
+	addr = fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
+	if err != nil {
+		t.Fatal("Couldn't start tcp listener", err)
+	}
+
+	server := &http.Server{Addr: "localhost:5050", Handler: TraceHandler(mux, monkit.ScopeNamed("server"), func(trace *monkit.Trace) {
+		trace.Set("testsampled", true)
+	})}
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	return addr, func() {
+		_ = server.Close()
+		_ = listener.Close()
+	}
+}

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,0 +1,7 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+/*
+Package http provides helper to propagate monkit traces via HTTP calls.
+*/
+package http

--- a/http/http.go
+++ b/http/http.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"net/http"
+)
+
+// Client is an interface that matches an http.Client
+type Client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type responseWriterObserver struct {
+	w  http.ResponseWriter
+	sc int
+}
+
+func (w *responseWriterObserver) WriteHeader(statusCode int) {
+	w.sc = statusCode
+	w.w.WriteHeader(statusCode)
+}
+
+func (w *responseWriterObserver) Write(p []byte) (n int, err error) {
+	if w.sc == 0 {
+		w.sc = 200
+	}
+	return w.w.Write(p)
+}
+
+func (w *responseWriterObserver) Header() http.Header {
+	return w.w.Header()
+}
+
+func (w *responseWriterObserver) StatusCode() int {
+	if w.sc == 0 {
+		return 200
+	}
+	return w.sc
+}

--- a/http/http.go
+++ b/http/http.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 )
 
-// Client is an interface that matches an http.Client
+// Client is an interface that matches a http.Client
 type Client interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/http/info.go
+++ b/http/info.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"fmt"
+	"github.com/spacemonkeygo/monkit/v3/present"
 	"strconv"
 	"strings"
 
@@ -53,7 +54,7 @@ type HeaderSetter interface {
 	Set(string, string)
 }
 
-// TraceInfoFromHeader will create a TraceInfo object given an http.Header or
+// TraceInfoFromHeader will create a TraceInfo object given a http.Header or
 // anything that matches the HeaderGetter interface.
 func TraceInfoFromHeader(header HeaderGetter) (rv TraceInfo) {
 	traceParent := header.Get(traceParentHeader)
@@ -101,10 +102,10 @@ func ref(v int64) *int64 {
 	return &v
 }
 
-func TraceInfoFromSpan(s *monkit.Span, sampledf func(trace *monkit.Trace) bool) TraceInfo {
+func TraceInfoFromSpan(s *monkit.Span) TraceInfo {
 	trace := s.Trace()
 
-	sampled := sampledf(trace)
+	sampled, _ := trace.Get(present.SampledKey).(bool)
 
 	if !sampled {
 		return TraceInfo{Sampled: sampled}

--- a/http/info.go
+++ b/http/info.go
@@ -16,11 +16,11 @@ package http
 
 import (
 	"fmt"
-	"github.com/spacemonkeygo/monkit/v3/present"
 	"strconv"
 	"strings"
 
 	"github.com/spacemonkeygo/monkit/v3"
+	"github.com/spacemonkeygo/monkit/v3/present"
 )
 
 // see: https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md

--- a/http/info.go
+++ b/http/info.go
@@ -29,7 +29,7 @@ const (
 	traceStateHeader  = "tracestate"
 
 	// orphanSampling is a special k,v which can be added to the vendor specific tracestate header.
-	// it can turn on trace sampling on remote even without propagataing the parent trace
+	// it can turn on trace sampling on remote even without propagating the parent trace
 	// (traceparent must not contain zero IDs)
 	// useful when you use curl (no client side tracing), and would like to get traces from the server.
 	orphanSampling = "sampled=true"

--- a/http/info.go
+++ b/http/info.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2014 Space Monkey, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spacemonkeygo/monkit/v3"
+)
+
+// see: https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md
+const (
+	traceSampled      = byte(1)
+	traceParentHeader = "traceparent"
+	traceStateHeader  = "tracestate"
+
+	// orphanSampling is a special k,v which can be added to the vendor specific tracestate header.
+	// it can turn on trace sampling on remote even without propagataing the parent trace
+	// (traceparent must not contain zero IDs)
+	// useful when you use curl (no client side tracing), and would like to get traces from the server.
+	orphanSampling = "sampled=true"
+)
+
+// TraceInfo is a structure representing an incoming RPC request. Every field
+// is optional.
+type TraceInfo struct {
+	TraceId  *int64
+	ParentId *int64
+	Sampled  bool
+}
+
+// HeaderGetter is an interface that http.Header matches for RequestFromHeader
+type HeaderGetter interface {
+	Get(string) string
+}
+
+// HeaderSetter is an interface that http.Header matches for TraceInfo.SetHeader
+type HeaderSetter interface {
+	Set(string, string)
+}
+
+// TraceInfoFromHeader will create a TraceInfo object given an http.Header or
+// anything that matches the HeaderGetter interface.
+func TraceInfoFromHeader(header HeaderGetter) (rv TraceInfo) {
+	traceParent := header.Get(traceParentHeader)
+	traceState := header.Get(traceStateHeader)
+
+	if traceParent != "" {
+		parts := strings.Split(traceParent, "-")
+		if len(parts) != 4 {
+			return rv
+		}
+		version, err := hexToUint64(parts[0])
+		if err != nil || version != 0 {
+			return rv
+		}
+		traceID, err := hexToUint64(parts[1])
+		if err != nil {
+			return rv
+		}
+		parentID, err := hexToUint64(parts[2])
+		if err != nil {
+			return rv
+		}
+		flags, err := hexToUint64(parts[3])
+		if err != nil {
+			return rv
+		}
+
+		return TraceInfo{
+			TraceId:  &traceID,
+			ParentId: &parentID,
+			Sampled:  (byte(flags) & traceSampled) == traceSampled,
+		}
+	}
+
+	// trace parent is not set, but tracing can be turned on by a traceState
+	if strings.Contains(traceState, "sampled=true") {
+		return TraceInfo{
+			Sampled: true,
+		}
+	}
+	return rv
+}
+
+func ref(v int64) *int64 {
+	return &v
+}
+
+func TraceInfoFromSpan(s *monkit.Span, sampledf func(trace *monkit.Trace) bool) TraceInfo {
+	trace := s.Trace()
+
+	sampled := sampledf(trace)
+
+	if !sampled {
+		return TraceInfo{Sampled: sampled}
+	}
+
+	req := TraceInfo{
+		TraceId:  ref(trace.Id()),
+		ParentId: ref(s.Id()),
+		Sampled:  sampled,
+	}
+	if parentID, hasParent := s.ParentId(); hasParent {
+		req.ParentId = ref(parentID)
+	}
+	return req
+}
+
+// SetHeader will take a TraceInfo and fill out an http.Header, or anything that
+// matches the HeaderSetter interface.
+func (r TraceInfo) SetHeader(header HeaderSetter) {
+	sampled := byte(0)
+	if r.Sampled {
+		sampled = traceSampled
+	}
+	if r.TraceId != nil && r.ParentId != nil {
+		header.Set(traceParentHeader, fmt.Sprintf("00-%016x-%08x-%x", *r.TraceId, *r.ParentId, int(sampled)))
+	} else if r.Sampled {
+		header.Set(traceStateHeader, orphanSampling)
+	}
+
+}
+
+// hexToUint64 reads a signed int64 that has been formatted as a hex uint64
+func hexToUint64(s string) (int64, error) {
+	v, err := strconv.ParseUint(s, 16, 64)
+	return int64(v), err
+}

--- a/http/info_test.go
+++ b/http/info_test.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package http
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		info           TraceInfo
+		expectedInfo   TraceInfo
+		expectedParent string
+		expectedState  string
+	}{
+		{
+			name: "not sampled, but with trace",
+			info: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(2),
+				Sampled:  false,
+			},
+			expectedInfo: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(2),
+				Sampled:  false,
+			},
+			expectedParent: "00-0000000000000001-00000002-0",
+			expectedState:  "",
+		},
+		{
+			name: "sampled",
+			info: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(16),
+				Sampled:  true,
+			},
+			expectedInfo: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(16),
+				Sampled:  true,
+			},
+			expectedParent: "00-0000000000000001-00000010-1",
+			expectedState:  "",
+		},
+		{
+			name: "sampled without trace",
+			info: TraceInfo{
+				TraceId:  nil,
+				ParentId: ref(16),
+				Sampled:  true,
+			},
+			expectedInfo: TraceInfo{
+				TraceId:  nil,
+				ParentId: nil,
+				Sampled:  true,
+			},
+			expectedParent: "",
+			expectedState:  "sampled=true",
+		},
+		{
+			name: "no trace, no sampled",
+			info: TraceInfo{
+				TraceId:  nil,
+				ParentId: ref(16),
+				Sampled:  false,
+			},
+			expectedInfo: TraceInfo{
+				TraceId:  nil,
+				ParentId: nil,
+				Sampled:  false,
+			},
+			expectedParent: "",
+			expectedState:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header := http.Header{}
+			tc.info.SetHeader(header)
+			if header.Get(traceParentHeader) != tc.expectedParent {
+				t.Fatalf("%s!=%s", tc.expectedParent, header.Get(traceParentHeader))
+			}
+			if header.Get(traceStateHeader) != tc.expectedState {
+				t.Fatalf("%s!=%s", tc.expectedState, header.Get(traceParentHeader))
+			}
+			rv := TraceInfoFromHeader(header)
+			checkEq(t, tc.expectedInfo.TraceId, rv.TraceId)
+			checkEq(t, tc.expectedInfo.ParentId, rv.ParentId)
+			if tc.expectedInfo.Sampled != rv.Sampled {
+				t.Fatalf("%v!=%v", tc.expectedInfo.Sampled, rv.Sampled)
+			}
+		})
+
+	}
+
+}
+
+func checkEq(t *testing.T, v1 *int64, v2 *int64) {
+	if v1 == nil && v2 == nil {
+		return
+	}
+	if v1 == nil || v2 == nil {
+		t.Fatalf("One value is nil, other isn't")
+	}
+	if *v1 != *v2 {
+		t.Fatalf("%d!=%d", v1, v2)
+	}
+}

--- a/http/server.go
+++ b/http/server.go
@@ -47,6 +47,10 @@ func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	}
 	defer t.scope.Func().RemoteTrace(&ctx, parent, trace)(nil)
 
+	if cb, exists := trace.Get(present.SampledCBKey).(func(*monkit.Trace)); exists {
+		cb(trace)
+	}
+
 	s := monkit.SpanFromCtx(ctx)
 	s.Annotate("http.uri", request.RequestURI)
 

--- a/http/server.go
+++ b/http/server.go
@@ -5,23 +5,22 @@ package http
 
 import (
 	"fmt"
+	"github.com/spacemonkeygo/monkit/v3/present"
 	"net/http"
 
 	"github.com/spacemonkeygo/monkit/v3"
 )
 
 // TraceHandler wraps a HTTPHandler and import trace information from header.
-func TraceHandler(c http.Handler, scope *monkit.Scope, sampler func(trace *monkit.Trace)) http.Handler {
+func TraceHandler(c http.Handler, scope *monkit.Scope) http.Handler {
 	return traceHandler{
 		handler: c,
-		sampler: sampler,
 		scope:   scope,
 	}
 }
 
 type traceHandler struct {
 	handler http.Handler
-	sampler func(trace *monkit.Trace)
 	scope   *monkit.Scope
 }
 
@@ -44,7 +43,7 @@ func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	}
 
 	if info.Sampled {
-		t.sampler(trace)
+		trace.Set(present.SampledKey, true)
 	}
 	defer t.scope.Func().RemoteTrace(&ctx, parent, trace)(nil)
 

--- a/http/server.go
+++ b/http/server.go
@@ -5,10 +5,10 @@ package http
 
 import (
 	"fmt"
-	"github.com/spacemonkeygo/monkit/v3/present"
 	"net/http"
 
 	"github.com/spacemonkeygo/monkit/v3"
+	"github.com/spacemonkeygo/monkit/v3/present"
 )
 
 // TraceHandler wraps a HTTPHandler and import trace information from header.

--- a/http/server.go
+++ b/http/server.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spacemonkeygo/monkit/v3"
+)
+
+// TraceHandler wraps a HTTPHandler and import trace information from header.
+func TraceHandler(c http.Handler, scope *monkit.Scope, sampler func(trace *monkit.Trace)) http.Handler {
+	return traceHandler{
+		handler: c,
+		sampler: sampler,
+		scope:   scope,
+	}
+}
+
+type traceHandler struct {
+	handler http.Handler
+	sampler func(trace *monkit.Trace)
+	scope   *monkit.Scope
+}
+
+// ServeHTTP implements http.Handler with span propagation.
+func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+
+	info := TraceInfoFromHeader(request.Header)
+
+	traceId := monkit.NewId()
+	if info.TraceId != nil {
+		traceId = *info.TraceId
+	}
+
+	trace := monkit.NewTrace(traceId)
+	ctx := request.Context()
+
+	parent := int64(0)
+	if info.ParentId != nil {
+		parent = *info.ParentId
+	}
+
+	if info.Sampled {
+		t.sampler(trace)
+	}
+	defer t.scope.Func().RemoteTrace(&ctx, parent, trace)(nil)
+
+	s := monkit.SpanFromCtx(ctx)
+	s.Annotate("http.uri", request.RequestURI)
+
+	wrapped := &responseWriterObserver{w: writer}
+	if info.ParentId == nil && info.Sampled {
+		writer.Header().Set(traceStateHeader, fmt.Sprintf("traceid=%d,spanid=%d", s.Id(), s.Trace().Id()))
+	}
+	t.handler.ServeHTTP(wrapped, request.WithContext(s))
+
+	s.Annotate("http.responsecode", fmt.Sprint(wrapped.StatusCode()))
+}


### PR DESCRIPTION
This pull request introduces new helper functions to propagate trace information according to the [w3c standard](https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md) 