### PR TITLE
http: fix format of trace information in the response header

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -56,7 +56,7 @@ func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 
 	wrapped, statusCode := Wrap(writer)
 	if info.ParentId == nil && info.Sampled {
-		writer.Header().Set(traceStateHeader, fmt.Sprintf("traceid=%d,spanid=%d", s.Id(), s.Trace().Id()))
+		writer.Header().Set(traceStateHeader, fmt.Sprintf("traceid=%x,spanid=%x", s.Trace().Id(), s.Id()))
 	}
 	t.handler.ServeHTTP(wrapped, request.WithContext(s))
 


### PR DESCRIPTION
monkit supports http tracing information in HTTP header.

If it's properly configured, it can be enabled with sg. like this:

```
curl -H "tracestate: sampled=true" ...
```

Response will include the Trace/SpandID to make it easier to find the trace on the server side (like Jaeger).

But:
 * Jaeger uses hex: might be better to switch to use hex ID
 * span/trace id was swapped
