### PR TITLE
http: use W3C recommended response headers

### DIFF
--- a/http/info.go
+++ b/http/info.go
@@ -23,11 +23,15 @@ import (
 	"github.com/spacemonkeygo/monkit/v3/present"
 )
 
-// see: https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md
 const (
+	// see: https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md
 	traceSampled      = byte(1)
 	traceParentHeader = "traceparent"
 	traceStateHeader  = "tracestate"
+
+	// see: https://github.com/w3c/trace-context/blob/main/spec/21-http_response_header_format.md
+	traceIDHeader = "trace-id"
+	childIDHeader = "child-id"
 
 	// orphanSampling is a special k,v which can be added to the vendor specific tracestate header.
 	// it can turn on trace sampling on remote even without propagating the parent trace

--- a/http/server.go
+++ b/http/server.go
@@ -56,7 +56,8 @@ func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 
 	wrapped, statusCode := Wrap(writer)
 	if info.ParentId == nil && info.Sampled {
-		writer.Header().Set(traceStateHeader, fmt.Sprintf("traceid=%x,spanid=%x", s.Trace().Id(), s.Id()))
+		writer.Header().Set(traceIDHeader, fmt.Sprintf("%x", s.Trace().Id()))
+		writer.Header().Set(childIDHeader, fmt.Sprintf("%x", s.Id()))
 	}
 	t.handler.ServeHTTP(wrapped, request.WithContext(s))
 


### PR DESCRIPTION
This patch modifies the way how the used traceID is reported back the the client with using header names compatible with the w3c recommendation:

https://github.com/w3c/trace-context/blob/main/spec/21-http_response_header_format.md