### PR TITLE
http: usage custom baggage headers as span annotations

### DIFF
--- a/http/client_test.go
+++ b/http/client_test.go
@@ -6,7 +6,6 @@ package http
 import (
 	"context"
 	"fmt"
-	"github.com/spacemonkeygo/monkit/v3/present"
 	"io"
 	"net"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/spacemonkeygo/monkit/v3"
+	"github.com/spacemonkeygo/monkit/v3/present"
 )
 
 type caller func(ctx context.Context, request *http.Request) (*http.Response, error)

--- a/http/info.go
+++ b/http/info.go
@@ -94,10 +94,12 @@ func TraceInfoFromHeader(header HeaderGetter, allowedBaggage ...string) (rv Trac
 		bm := map[string]string{}
 		if baggage != "" {
 			for _, kv := range strings.Split(baggage, ",") {
-				parts := strings.Split(kv, "=")
-				for _, b := range allowedBaggage {
-					if parts[0] == b {
-						bm[parts[0]] = parts[1]
+				if key, value, ok := strings.Cut(kv, "="); ok {
+					for _, b := range allowedBaggage {
+						if key == b {
+							bm[key] = value
+							break
+						}
 					}
 				}
 			}

--- a/http/info_test.go
+++ b/http/info_test.go
@@ -62,6 +62,27 @@ func TestSetHeader(t *testing.T) {
 			expectedState:  "sampled=true",
 		},
 		{
+			name: "sampled  with baggage",
+			info: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(16),
+				Sampled:  true,
+				Baggage: map[string]string{
+					"k": "v1",
+				},
+			},
+			expectedInfo: TraceInfo{
+				TraceId:  ref(1),
+				ParentId: ref(16),
+				Sampled:  true,
+				Baggage: map[string]string{
+					"k": "v1",
+				},
+			},
+			expectedParent: "00-0000000000000001-00000010-1",
+			expectedState:  "",
+		},
+		{
 			name: "no trace, no sampled",
 			info: TraceInfo{
 				TraceId:  nil,
@@ -88,11 +109,22 @@ func TestSetHeader(t *testing.T) {
 			if header.Get(traceStateHeader) != tc.expectedState {
 				t.Fatalf("%s!=%s", tc.expectedState, header.Get(traceParentHeader))
 			}
-			rv := TraceInfoFromHeader(header)
+			rv := TraceInfoFromHeader(header, "k")
 			checkEq(t, tc.expectedInfo.TraceId, rv.TraceId)
 			checkEq(t, tc.expectedInfo.ParentId, rv.ParentId)
 			if tc.expectedInfo.Sampled != rv.Sampled {
 				t.Fatalf("%v!=%v", tc.expectedInfo.Sampled, rv.Sampled)
+			}
+			for k, v := range rv.Baggage {
+				if tc.expectedInfo.Baggage[k] != v {
+					t.Fatalf("%v!=%v", tc.expectedInfo.Baggage[k], v)
+				}
+
+			}
+			for k, v := range tc.expectedInfo.Baggage {
+				if rv.Baggage[k] != v {
+					t.Fatalf("%v!=%v", rv.Baggage[k], v)
+				}
 			}
 		})
 

--- a/http/server.go
+++ b/http/server.go
@@ -12,11 +12,11 @@ import (
 )
 
 // TraceHandler wraps a HTTPHandler and import trace information from header.
-func TraceHandler(c http.Handler, scope *monkit.Scope, baggageFilter ...string) http.Handler {
+func TraceHandler(c http.Handler, scope *monkit.Scope, allowedBaggage ...string) http.Handler {
 	return traceHandler{
-		handler:       c,
-		scope:         scope,
-		baggageFilter: baggageFilter,
+		handler:        c,
+		scope:          scope,
+		allowedBaggage: allowedBaggage,
 	}
 }
 
@@ -24,14 +24,14 @@ type traceHandler struct {
 	handler http.Handler
 	scope   *monkit.Scope
 
-	// baggageFilter defines the allowed `baggage: k=v` HTTP headers which are imported as scan annotations.
-	baggageFilter []string
+	// allowedBaggage defines the allowed `baggage: k=v` HTTP headers which are imported as scan annotations.
+	allowedBaggage []string
 }
 
 // ServeHTTP implements http.Handler with span propagation.
 func (t traceHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
-	info := TraceInfoFromHeader(request.Header, t.baggageFilter...)
+	info := TraceInfoFromHeader(request.Header, t.allowedBaggage...)
 
 	traceId := monkit.NewId()
 	if info.TraceId != nil {


### PR DESCRIPTION
This patch allows using "baggage: k1=v1,k2=v2" header, where the keys and values can be imported as span (assuming the key name is on the white list).

This feature can be used to tag/annotate distributed traces with the help of HTTP header, which makes it easier to find the right traces in the db (without using exemplars).
