### PR TITLE
scope: add RawVal type for raw float64 values

### DIFF
--- a/examples/minimal/main.go
+++ b/examples/minimal/main.go
@@ -50,6 +50,8 @@ func ComputeThing(ctx context.Context, arg1, arg2 int) (res int, err error) {
 		mon.Event("hit 3")
 	}
 
+	mon.RawVal("raw").Observe(1.0)
+	mon.RawValk(monkit.NewSeriesKey("rawk").WithTag("foo", "bar"), monkit.Sum, monkit.Count).Observe(1.0)
 	mon.BoolVal("was-4").Observe(res == 4)
 	mon.IntVal("res").Observe(int64(res))
 	mon.DurationVal("took").Observe(time.Second + time.Duration(rand.Intn(int(10*time.Second))))

--- a/scope.go
+++ b/scope.go
@@ -233,6 +233,29 @@ func (s *Scope) DurationVal(name string, tags ...SeriesTag) *DurationVal {
 	return m
 }
 
+// RawValk retrieves or creates a RawVal with a given key and aggregations.
+func (s *Scope) RawValk(key SeriesKey, aggregations ...Aggregate) *RawVal {
+	source := s.newSource(key.String(), func() StatSource {
+		return NewRawVal(key, aggregations...)
+	})
+	m, ok := source.(*RawVal)
+	if !ok {
+		panic(fmt.Sprintf("%s already used for another stats source: %#v", key, source))
+	}
+	return m
+}
+
+// RawVal retrieves or creates a RawVal after the given name and tags.
+func (s *Scope) RawVal(name string, tags ...SeriesTag) *RawVal {
+	return s.RawValk(NewSeriesKey(name).WithTags(tags...))
+}
+
+// RawValf retrieves or creates a RawVal after the given printf-formatted
+// name.
+func (s *Scope) RawValf(template string, args ...interface{}) *RawVal {
+	return s.RawVal(fmt.Sprintf(template, args...))
+}
+
 // Timer retrieves or creates a Timer after the given name.
 func (s *Scope) Timer(name string, tags ...SeriesTag) *Timer {
 	source := s.newSource(sourceName("", name, tags), func() StatSource {


### PR DESCRIPTION
Adds a new RawVal type to store raw float64 values without any aggregation (histogram, sum, etc).
This provides a simpler alternative to FloatVal when only the most recent value is needed.

With high cardinality data, it's important to use only minimal fields (especially as Prometheus/Victoria can calculate the sum/min/max aggregations)
