### PR TITLE
present: add min_duration filter for trace endpoints

### DIFF
--- a/present/trace.go
+++ b/present/trace.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
-	"fmt"
 	"io"
 	"strings"
 	"text/template"
@@ -454,7 +453,7 @@ func watchForSpansWithMinDuration(ctx context.Context, reg *monkit.Registry, w i
 			return nil, err
 		}
 		if len(spans) == 0 {
-			return nil, fmt.Errorf("no spans collected")
+			continue
 		}
 
 		// Check root span duration


### PR DESCRIPTION
Add optional min_duration query parameter to /trace/svg and /trace/json endpoints that filters traces based on their duration. Only traces where the matched span's duration exceeds the specified threshold are returned.

Usage examples:
/trace/svg?regex=MyFunc&min_duration=2s
/trace/json?regex=SlowOp&min_duration=500ms

This feature helps in debugging by allowing users to capture only traces that exceed a certain performance threshold, making it easier to identify slow operations.